### PR TITLE
Store tuple index in least significant bits

### DIFF
--- a/tsl/src/compression/arrow_tts.h
+++ b/tsl/src/compression/arrow_tts.h
@@ -12,6 +12,8 @@
 
 #include "arrow_c_data_interface.h"
 
+#include <limits.h>
+
 typedef struct ArrowTupleTableSlot
 {
 	VirtualTupleTableSlot base;
@@ -36,32 +38,57 @@ extern TupleTableSlot *ExecStoreArrowTupleExisting(TupleTableSlot *slot, uint16 
 #define InvalidTupleIndex 0
 #define MaxCompressedBlockNumber ((BlockNumber) 0x3FFFFF)
 
+#define BLOCKID_BITS (CHAR_BIT * sizeof(BlockIdData))
+#define COMPRESSED_FLAG (1UL << (BLOCKID_BITS - 1))
+#define OFFSET_BITS (CHAR_BIT * sizeof(OffsetNumber))
+#define OFFSET_MASK (((uint64) 1 << OFFSET_BITS) - 1)
+#define TUPINDEX_BITS (10)
+#define TUPINDEX_MASK (((uint64) 1 << TUPINDEX_BITS) - 1)
+
+/* Compute a 64-bits value from the item pointer data */
+static uint64
+bits_from_tid(ItemPointer tid)
+{
+	return (ItemPointerGetBlockNumber(tid) << OFFSET_BITS) | ItemPointerGetOffsetNumber(tid);
+}
+
+/*
+ * The "compressed TID" consists of the bits of the TID for the compressed row
+ * shifted to insert the tuple index as the least significant bits of the TID.
+ */
 static inline void
 tid_to_compressed_tid(ItemPointer out_tid, ItemPointer in_tid, uint16 tuple_index)
 {
-	BlockNumber blockno = ItemPointerGetBlockNumber(in_tid);
-	OffsetNumber offsetno = ItemPointerGetOffsetNumber(in_tid);
-	BlockNumber compressed_blockno;
+	uint64 bits = (bits_from_tid(in_tid) << TUPINDEX_BITS) | tuple_index;
 
-	Assert(blockno <= MaxCompressedBlockNumber);
-
-	compressed_blockno = ((tuple_index & 0x3FF) << 22) | blockno;
-	ItemPointerSet(out_tid, compressed_blockno, offsetno);
+	/* Insert the tuple index as the least significant bits and set the most
+	 * significant bit of the block id to mark it as a compressed tuple. */
+	BlockNumber blockno = COMPRESSED_FLAG | (bits >> OFFSET_BITS);
+	OffsetNumber offsetno = bits & OFFSET_MASK;
+	elog(LOG, "%s - blockno: %d, offsetno: %d", __func__, blockno, offsetno);
+	ItemPointerSet(out_tid, blockno, offsetno);
 }
 
 static inline uint16
 compressed_tid_to_tid(ItemPointer out_tid, ItemPointer in_tid)
 {
-	BlockNumber blockno = ItemPointerGetBlockNumber(in_tid);
-	OffsetNumber offsetno = ItemPointerGetOffsetNumber(in_tid);
-	uint16 tuple_index = (blockno >> 22);
-	BlockNumber orig_blockno = (blockno & 0x3FFFFF);
+	uint64 orig_bits = bits_from_tid(in_tid);
+	const uint16 tuple_index = orig_bits & TUPINDEX_MASK;
 
-	ItemPointerSet(out_tid, orig_blockno, offsetno);
+	/* Remove the tuple index bits and clear the compressed flag from the block id. */
+	uint64 bits = orig_bits >> TUPINDEX_BITS;
+	BlockNumber blockno = ~COMPRESSED_FLAG & (bits >> OFFSET_BITS);
+	OffsetNumber offsetno = bits & OFFSET_MASK;
+	elog(LOG, "%s - blockno: %d, offsetno: %d", __func__, blockno, offsetno);
+	ItemPointerSet(out_tid, blockno, offsetno);
 
 	return tuple_index;
 }
 
-#define is_compressed_tid(itemptr) ((ItemPointerGetBlockNumber(itemptr) >> 22) != 0)
+static inline bool
+is_compressed_tid(ItemPointer itemptr)
+{
+	return (ItemPointerGetBlockNumber(itemptr) & COMPRESSED_FLAG) != 0;
+}
 
 #endif /* PG_ARROW_TUPTABLE_H */

--- a/tsl/test/expected/compression_tam.out
+++ b/tsl/test/expected/compression_tam.out
@@ -1,0 +1,63 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+CREATE TABLE readings(time timestamptz, location int, device int, temp float, humidity float);
+SELECT create_hypertable('readings', 'time');
+NOTICE:  adding not-null constraint to column "time"
+   create_hypertable   
+-----------------------
+ (1,public,readings,t)
+(1 row)
+
+-- INSERT INTO readings (time, location, device, temp, humidity)
+-- SELECT t, ceil(random()*10), ceil(random()*30), random()*40, random()*100
+-- FROM generate_series('2022-06-01'::timestamptz, '2022-07-01', '5s') t;
+INSERT INTO readings(time, location, device, temp, humidity)
+   VALUES
+	('2022-06-01', 1, 15, 20, 47),
+	('2022-06-02', 1, 16, 22, 49);
+ALTER TABLE readings SET (
+      timescaledb.compress,
+      timescaledb.compress_orderby = 'time',
+      timescaledb.compress_segmentby = 'device'
+);
+SELECT format('%I.%I', chunk_schema, chunk_name)::regclass AS chunk
+  FROM timescaledb_information.chunks
+ WHERE format('%I.%I', hypertable_schema, hypertable_name)::regclass = 'readings'::regclass
+ LIMIT 1 \gset
+SELECT device, count(*) FROM readings GROUP BY device ORDER BY device;
+ device | count 
+--------+-------
+     15 |     1
+     16 |     1
+(2 rows)
+
+-- We should be able to set the table access method for a chunk, which
+-- will automatically compress the chunk.
+ALTER TABLE :chunk SET ACCESS METHOD tscompression;
+WARNING:  unrecognized node type: 231
+-- This should compress the chunk
+SELECT chunk_name FROM chunk_compression_stats('readings') WHERE compression_status='Compressed';
+    chunk_name    
+------------------
+ _hyper_1_1_chunk
+(1 row)
+
+-- Should give the same result as above
+SELECT device, count(*) FROM readings GROUP BY device ORDER BY device;
+ device | count 
+--------+-------
+     15 |     1
+     16 |     1
+(2 rows)
+
+-- We should be able to change it back to heap.
+ALTER TABLE :chunk SET ACCESS METHOD heap;
+-- Should give the same result as above
+SELECT device, count(*) FROM readings GROUP BY device ORDER BY device;
+ device | count 
+--------+-------
+     15 |     1
+     16 |     1
+(2 rows)
+

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_FILES
     compressed_collation.sql
     compression_create_compressed_table.sql
     compression_bgw.sql
+    compression_tam.sql
     compression_conflicts.sql
     compression_insert.sql
     compression_policy.sql

--- a/tsl/test/sql/compression_tam.sql
+++ b/tsl/test/sql/compression_tam.sql
@@ -1,0 +1,45 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+CREATE TABLE readings(time timestamptz, location int, device int, temp float, humidity float);
+
+SELECT create_hypertable('readings', 'time');
+
+-- INSERT INTO readings (time, location, device, temp, humidity)
+-- SELECT t, ceil(random()*10), ceil(random()*30), random()*40, random()*100
+-- FROM generate_series('2022-06-01'::timestamptz, '2022-07-01', '5s') t;
+
+INSERT INTO readings(time, location, device, temp, humidity)
+   VALUES
+	('2022-06-01', 1, 15, 20, 47),
+	('2022-06-02', 1, 16, 22, 49);
+
+ALTER TABLE readings SET (
+      timescaledb.compress,
+      timescaledb.compress_orderby = 'time',
+      timescaledb.compress_segmentby = 'device'
+);
+
+SELECT format('%I.%I', chunk_schema, chunk_name)::regclass AS chunk
+  FROM timescaledb_information.chunks
+ WHERE format('%I.%I', hypertable_schema, hypertable_name)::regclass = 'readings'::regclass
+ LIMIT 1 \gset
+
+SELECT device, count(*) FROM readings GROUP BY device ORDER BY device;
+
+-- We should be able to set the table access method for a chunk, which
+-- will automatically compress the chunk.
+ALTER TABLE :chunk SET ACCESS METHOD tscompression;
+
+-- This should compress the chunk
+SELECT chunk_name FROM chunk_compression_stats('readings') WHERE compression_status='Compressed';
+
+-- Should give the same result as above
+SELECT device, count(*) FROM readings GROUP BY device ORDER BY device;
+
+-- We should be able to change it back to heap.
+ALTER TABLE :chunk SET ACCESS METHOD heap;
+
+-- Should give the same result as above
+SELECT device, count(*) FROM readings GROUP BY device ORDER BY device;


### PR DESCRIPTION
Instead of storing the tuple index in the block number, we modify the item pointer so that we store the tuple index in the least significant bits of the TID.